### PR TITLE
Add support to tag objects on import

### DIFF
--- a/importing/import_objects.py
+++ b/importing/import_objects.py
@@ -210,7 +210,7 @@ def import_objects(file_name, client, changed_layer_names, package, layer=None, 
 
 def add_tag_to_object(tag_name, payload, api_type, client):
     # types don't support tagging
-    if "rule" in api_type or "section" in api_type:
+    if "rule" in api_type or "section" in api_type or "threat-exception" in api_type:
         return
 
     global add_tag_to_object_uid

--- a/importing/import_package.py
+++ b/importing/import_package.py
@@ -3,7 +3,7 @@ import time
 
 import sys
 
-from importing.import_objects import import_objects, add_tag_to_object
+from importing.import_objects import import_objects, add_tag_to_object_payload
 from utils import debug_log, generate_import_error_report, count_global_layers
 
 
@@ -33,7 +33,7 @@ def import_package(client, args):
         debug_log("Creating a Policy Package named [" + package + "]", True)
         package_payload = {"name": package, "access": True, "threat-prevention": True}
         if args.tag_objects_on_import != "":
-            add_tag_to_object(args.tag_objects_on_import, package_payload, "package", client)
+            add_tag_to_object_payload(args.tag_objects_on_import, package_payload, "package", client)
         client.api_call("add-package", package_payload)
         client.api_call("publish", wait_for_task=True)
     else:

--- a/importing/import_package.py
+++ b/importing/import_package.py
@@ -3,7 +3,7 @@ import time
 
 import sys
 
-from importing.import_objects import import_objects
+from importing.import_objects import import_objects, add_tag_to_object
 from utils import debug_log, generate_import_error_report, count_global_layers
 
 
@@ -31,7 +31,10 @@ def import_package(client, args):
     show_package = client.api_call("show-package", {"name": package, "details-level": "full"})
     if "code" in show_package.data and "not_found" in show_package.data["code"]:
         debug_log("Creating a Policy Package named [" + package + "]", True)
-        client.api_call("add-package", {"name": package, "access": True, "threat-prevention": True})
+        package_payload = {"name": package, "access": True, "threat-prevention": True}
+        if args.tag_objects_on_import != "":
+            add_tag_to_object(args.tag_objects_on_import, package_payload, "package", client)
+        client.api_call("add-package", package_payload)
         client.api_call("publish", wait_for_task=True)
     else:
         if not args.force:

--- a/lists_and_dictionaries.py
+++ b/lists_and_dictionaries.py
@@ -674,7 +674,7 @@ no_export_fields_and_subfields = ["read-only", "layer", "package", "owner", "ico
 no_export_fields_by_api_type = {
     "host": ["standard-port-number", "subnet-mask", "type"],
     "network": ["subnet-mask"],
-    "threat-rule": ["exceptions"],
+    "threat-rule": ["exceptions", "exceptions-layer"],
     "simple-gateway": ["forward-logs-to-log-server-schedule-name", "hardware", "dynamic-ip", "sic-name", "sic-state",
                        "send-alerts-to-server",
                        "send-logs-to-backup-server", "send-logs-to-server", "interfaces"],

--- a/lists_and_dictionaries.py
+++ b/lists_and_dictionaries.py
@@ -730,3 +730,4 @@ not_unique_name_with_dedicated_api = {
     "Unknown Traffic": "show-application-site-category"
 }
 
+types_not_support_tagging = ["rule", "section", "threat-exception"]

--- a/utils.py
+++ b/utils.py
@@ -76,6 +76,8 @@ def populate_parser(parser):
                         help="Stop import on first API error.")
     parser.add_argument("--skip-import-sections", required=False, default=False, type=str2bool,
                         help="Skip import layer sections.")
+    parser.add_argument("--tag-objects-on-import", required=False, default="",
+                        help="Add tag to supported objects on import.")
     return parser.parse_args()
 
 


### PR DESCRIPTION
1. Add flag '--tag-objects-on-import' to tag objects on import.
2. Bug fix - Decode version from file to utf-8.
3. Bug fix - Not to export 'exceptions-layer' field of threat-rule objects.
