### PR TITLE
Fixes script ignoring session id envar.

### DIFF
--- a/import_export_package.py
+++ b/import_export_package.py
@@ -60,7 +60,10 @@ if __name__ == "__main__":
             handle_login_fail(not test_reply.success, "Extract SID is invalid!")
             get_version(client)
         elif args.login == '4':
-            client.sid = input("Please enter sid: ")
+            if args.session_id:
+                client.sid = args.session_id
+            else:
+                client.sid = input("Please enter sid: ")
             test_reply = client.api_call("show-hosts", {"limit": 1})
             handle_login_fail(not test_reply.success, "Supplied SID is invalid!")
             get_version(client)


### PR DESCRIPTION
The script will always prompt the user for a session id, even if session id is set as an envar. This PR fixes it so that if envar `MGMT_CLI_SESSION_ID` exists, use it.